### PR TITLE
Dynamically create the executor

### DIFF
--- a/apimux/constants.py
+++ b/apimux/constants.py
@@ -2,7 +2,5 @@ LOGGER_NAME = 'apimux'
 LOG_LEVEL = 5
 LOG_TO_FILE = "apimux.log"
 
-MAX_WORKERS = 8
-
 # Periodic check of the response time of the API
 PERIODIC_CHECK = 3  # s


### PR DESCRIPTION
Currently the executor gets created on class initialization.
This creates a problem when multiple requests are coming
at the same time. There will always be the same number of
workers in the executor which will stall the future requests
until the past requests have completed.

To address this issue, the executor will now be created
when the method gets called.